### PR TITLE
Add iframe playback for games

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -295,9 +295,11 @@ export default function GameDevPortfolio() {
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
                         <div className="flex space-x-4">
-                          <Button size="sm" className="bg-purple-600 hover:bg-purple-700">
-                            <Play className="mr-2 h-4 w-4" />
-                            Play
+                          <Button size="sm" asChild className="bg-purple-600 hover:bg-purple-700">
+                            <a href={`/play?id=${index}`}> 
+                              <Play className="mr-2 h-4 w-4" />
+                              Play
+                            </a>
                           </Button>
                           <Button
                             size="sm"

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,10 +1,13 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
 import GameCanvas from "@/components/GameCanvas"
 
 export default function GameDevPortfolioPlay() {
   const [activeSection, setActiveSection] = useState("hero")
+  const [gameUrl, setGameUrl] = useState<string | null>(null)
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     const handleScroll = () => {
@@ -28,6 +31,20 @@ export default function GameDevPortfolioPlay() {
     window.addEventListener("scroll", handleScroll)
     return () => window.removeEventListener("scroll", handleScroll)
   }, [])
+
+  useEffect(() => {
+    const id = searchParams.get("id")
+    if (!id) return
+
+    fetch(`/api/play/${id}`, { method: "POST" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.gameurl) {
+          setGameUrl(data.gameurl)
+        }
+      })
+      .catch(() => setGameUrl(null))
+  }, [searchParams])
 
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId)
@@ -62,7 +79,14 @@ export default function GameDevPortfolioPlay() {
       {/* Canvas Section */}
       <section id="hero" className="pt-24 container mx-auto px-4">
         <h2 className="text-4xl font-bold text-white text-center mb-4">Play</h2>
-        <GameCanvas />
+        {gameUrl ? (
+          <iframe
+            src={gameUrl}
+            className="w-full h-[600px] mx-auto my-8 bg-black rounded shadow-md"
+          />
+        ) : (
+          <GameCanvas />
+        )}
       </section>
     </div>
   )


### PR DESCRIPTION
## Summary
- add search param handling and API call to play page
- display games in an iframe if a game URL is available
- link feature cards' Play button to `/play` with the game index

## Testing
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_6864d3406ae08329853c281938d7bc7e